### PR TITLE
Eliminating sidebarMobileDefaultHides

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -45,7 +45,7 @@ $conf['sidebarLeftRow1']        = 'logged in user';
 $conf['sidebarLeftRow2']        = 'search';
 $conf['sidebarLeftRow3']        = 'content';
 $conf['sidebarLeftRow4']        = 'none';
-$conf['sidebarMobileDefaultHide']	= 1;
+$conf['sidebarMobileDefaultCollapse']	= 1;
 $conf['sidebarShowRight']       = 1;
 
 $conf['tocFull']                = 0;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -46,7 +46,7 @@ $meta['sidebarLeftRow1']        = array('multichoice', '_choices' => array('none
 $meta['sidebarLeftRow2']        = array('multichoice', '_choices' => array('none', 'logged in user', 'search', 'content', 'tags'));
 $meta['sidebarLeftRow3']        = array('multichoice', '_choices' => array('none', 'logged in user', 'search', 'content', 'tags'));
 $meta['sidebarLeftRow4']        = array('multichoice', '_choices' => array('none', 'logged in user', 'search', 'content', 'tags'));
-$meta['sidebarMobileDefaultHide']	= array('onoff');
+$meta['sidebarMobileDefaultCollapse']	= array('onoff');
 $meta['sidebarShowRight']       = array('onoff');
 
 $meta['tocFull']                = array('onoff');

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -45,7 +45,7 @@ $lang['sidebarLeftRow1']        = 'Content to show in the first row on the left 
 $lang['sidebarLeftRow2']        = 'Content to show in the second row on the left sidebar';
 $lang['sidebarLeftRow3']        = 'Content to show in the third row on the left sidebar';
 $lang['sidebarLeftRow4']        = 'Content to show in the forth row on the left sidebar';
-$lang['sidebarMobileDefaultHide']	= 'Hide the sidebars by default when in mobile view';
+$lang['sidebarMobileDefaultCollapse']	= 'Hide the sidebars by default when in mobile view';
 $lang['sidebarShowRight']       = 'Show the right sidebar';
 
 $lang['tocFull']                = 'Show the TOC as a full height element';


### PR DESCRIPTION
Should be `sidebarMobileDefaultCollapse` globally.

I've noticed `sidebarMobileDefaultCollapse` was introduced in 54fe5c9, but there seemed to be a regression in c9c2db9.