### PR TITLE
Add support for deferred JavaScript

### DIFF
--- a/mikio.php
+++ b/mikio.php
@@ -77,6 +77,7 @@ class Template
     public function metaHeadersHandler(\Doku_Event $event)
     {
         global $MIKIO_ICONS;
+        global $conf;
 
         $this->includePage('theme', FALSE, TRUE);
 

--- a/mikio.php
+++ b/mikio.php
@@ -147,7 +147,8 @@ class Template
                 $event->data['script'][] = array(
                     'type'  => 'text/javascript',
                     '_data' => '',
-                    'src'   => $script
+                    'src'   => $script,
+                    'defer' => 'defer',
                 );
             }
             $set[] = $script;

--- a/mikio.php
+++ b/mikio.php
@@ -144,12 +144,15 @@ class Template
         $set = [];
         foreach ($scripts as $script) {
             if (in_array($script, $set) == FALSE) {
-                $event->data['script'][] = array(
+                $script_params = array(
                     'type'  => 'text/javascript',
                     '_data' => '',
-                    'src'   => $script,
-                    'defer' => 'defer',
+                    'src'   => $script
                 );
+                if ($conf['defer_js']) {
+                    $script_params += ['defer' => 'defer'];
+                }
+                $event->data['script'][] = $script_params;
             }
             $set[] = $script;
         }


### PR DESCRIPTION
Currently, all JavaScript from this template is always loaded immediately (without the defer attribute). This can have a negative impact on performance. It also means that, should it depend on any JavaScript from the core DokuWiki and [defer_js](https://www.dokuwiki.org/config:defer_js) is turned on, it can break. Therefore, this pull request modifies the code inserting the JavaScript so it will check whether `defer_js` is true and act accordingly.