### PR TITLE
Fixed searching for images in the theme directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,10 @@ The following pages can be either html files in the root of the template or a pa
 
 ## Include Images
 
-The following images can be used to replace content in the template. Images can be in the root of the template or in the namespace. Images can be either png, jpg, gif or svg.
+The following images can be used to replace content in the
+template. Images can be in `TEMPLATE_ROOT/images/`,
+`TEMPLATE_ROOT/themes/THEME/images/`, or in the namespace. Images can
+be either png, jpg, gif or svg.
 
 - `logo` : site logo in the navbar
 - `breadcrumb-prefix` breadcrumb prefix

--- a/mikio.php
+++ b/mikio.php
@@ -1641,7 +1641,7 @@ class Template
             $prefix[] = ':wiki:';
         }
         $theme = $this->getConf('customTheme');
-        if ($theme != '') $prefix[] = $this->tplDir . 'themes/' . $theme . '/images/';
+        if ($theme != '') $prefix[] = 'themes/' . $theme . '/images/';
         $prefix[] = 'images/';
 
         $search = array();


### PR DESCRIPTION
The way `Template->getMediaFile()` was written meant that, when looking for media files in the theme directory, it prepended the absolute path of the template directory twice. E.g., it would be looking for a file at  `/home/username/public_html/lib/tpl/mikio//home/username/public_html/lib/tpl/mikio/themes/themename/images/logo.png` rather than simply `/home/username/public_html/lib/tpl/mikio/themes/themename/images/logo.png`. This pull request fixes that bug. It also clarifies the documentation in the README about where exactly the images can be placed.