### PR TITLE
In "Page editors" mode, show the editor toolbar if a page is editable by this user, rather than if the user is admin/manager/owner

### DIFF
--- a/mikio.php
+++ b/mikio.php
@@ -893,11 +893,7 @@ data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">' .
                     }//end if
 
                     if(empty($logo) === false) {
-<<<<<<< HEAD
                         $html .= '<img src="' . $logo . '" alt="'. strip_tags($conf['title']) .' logo" class="mikio-navbar-brand-image' . (empty($logoDark) === false ? ' mikio-light-only' : '') . '"' . $styles . '>';
-=======
-                        $html .= '<img src="' . $logo . '" class="mikio-navbar-brand-image' . (empty($logoDark) === false ? ' mikio-light-only' : '') . '"' . $styles . '>';
->>>>>>> 828d0c8 (remove alt tag from logo)
                     }
 
                     if (empty($logoDark) === false) {
@@ -2245,17 +2241,11 @@ data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">' .
         if (@file_exists($wiki_file) === false) {
             return true;
         }
-        if ($INFO['isadmin'] === true || $INFO['ismanager'] === true) {
-            return true;
-        }
-        // $meta_file = metaFN($ID, '.meta');
-        if ($INFO['meta']['user'] === false) {
-            return true;
-        }
-        if ($INFO['client'] === $INFO['meta']['user']) {
-            return true;
-        }
 
+        if($INFO['editable'] === true) {
+            return true;
+        }
+        
         return false;
     }
 


### PR DESCRIPTION
I believe this check should be more reliable for different access control configs. This modifies the `userCanEdit` function to check the `editable` flag in the `$INFO` array, rather than checking if the file is owned by this user, last edited by this user, or the user is an admin / manager.

Resolves https://github.com/nomadjimbob/mikio/issues/120